### PR TITLE
Fix appointment namespaces

### DIFF
--- a/app/controller/AppointmentController.php
+++ b/app/controller/AppointmentController.php
@@ -1,8 +1,8 @@
 <?php
-namespace app\controllers;
+namespace app\controller;
 
-use app\utils\Database;
-use app\models\AppointmentDao;
+use app\_utils\Database;
+use app\dao\dashboard\AppointmentDao;
 
 class AppointmentController {
     private $dao;

--- a/app/controller/dashboard/AppointmentController.php
+++ b/app/controller/dashboard/AppointmentController.php
@@ -4,13 +4,13 @@ namespace app\controller\dashboard;
 require_once(__DIR__ . '/../ICrudController.php');
 require_once(__DIR__ . '/../../model/UserDao.php');
 require_once(__DIR__ . '/../../model/dashboard/ServiceDao.php'); 
-require_once(__DIR__ . '/../../model/dashboard/AppointmentDao.php');
+require_once(__DIR__ . '/../../dao/dashboard/AppointmentDao.php');
 
 
 use app\controller\ICrudController;
 use app\model\UserDao;
 use app\model\dashboard\ServiceDao;
-use app\model\dashboard\AppointmentDao;
+use app\dao\dashboard\AppointmentDao;
 use app\model\dashboard\Appointment;
 
 class AppointmentController implements ICrudController 
@@ -27,20 +27,20 @@ class AppointmentController implements ICrudController
     }
     
     public function updateAppointment($id, $clientName, $serviceId, $appointmentDate, $appointmentTime) {
-        require_once '../dao/AppointmentDao.php';
+        require_once __DIR__ . '/../../dao/dashboard/AppointmentDao.php';
         $dao = new AppointmentDao();
         return $dao->updateAppointment($id, $clientName, $serviceId, $appointmentDate, $appointmentTime);
     }
 
     public function deleteAppointment($id) {
-        require_once __DIR__ . '/../../../dao/AppointmentDao.php';
+        require_once __DIR__ . '/../../../dao/dashboard/AppointmentDao.php';
         $dao = new AppointmentDao();
         return $dao->deleteAppointment($id);
     }
     
 
     public function getAppointmentById($id) {
-        require_once __DIR__ . '/../../../dao/AppointmentDao.php';
+        require_once __DIR__ . '/../../../dao/dashboard/AppointmentDao.php';
         $dao = new AppointmentDao();
         return $dao->getById($id);
     }
@@ -58,7 +58,7 @@ class AppointmentController implements ICrudController
 }
 
 public function addAppointment($clientName, $serviceId, $appointmentDate, $appointmentTime) {
-    require_once '../dao/AppointmentDao.php';
+    require_once __DIR__ . '/../../dao/dashboard/AppointmentDao.php';
     $dao = new AppointmentDao();
     return $dao->insertAppointment($clientName, $serviceId, $appointmentDate, $appointmentTime);
 }

--- a/app/dao/dashboard/AppointmentDao.php
+++ b/app/dao/dashboard/AppointmentDao.php
@@ -1,5 +1,5 @@
 <?php
-namespace app\dao;
+namespace app\dao\dashboard;
 
 use app\_utils\Database;
 

--- a/app/model/Appointment.php
+++ b/app/model/Appointment.php
@@ -2,7 +2,7 @@
 
 namespace app\controller;
 
-use app\dao\AppointmentDao;
+use app\dao\dashboard\AppointmentDao;
 use app\_utils\Database;
 
 class AppointmentController

--- a/app/routes/appointment.php
+++ b/app/routes/appointment.php
@@ -1,5 +1,5 @@
 <?php
-use App\Controllers\AppointmentController;
+use app\controller\AppointmentController;
 
 $controller = new AppointmentController();
 

--- a/app/routes/user.php
+++ b/app/routes/user.php
@@ -1,5 +1,5 @@
 <?php
-use app\controllers\UserController;
+use app\controller\UserController;
 
 $controller = new UserController();
 


### PR DESCRIPTION
## Notes
- Fixed incorrect namespaces in controllers and routes
- Updated AppointmentDao namespace to match folder

## Summary
- corrected namespace usage in `AppointmentController`
- updated API routes to use the right controllers
- adjusted paths in dashboard controller
- fixed AppointmentDao namespace and references


------
https://chatgpt.com/codex/tasks/task_e_683f01e5d838832d80fb43a53f9c6640